### PR TITLE
On slot connect, pass slot_data to handler

### DIFF
--- a/apclient.hpp
+++ b/apclient.hpp
@@ -145,7 +145,7 @@ public:
         _hOnSocketDisconnected = f;
     }
 
-    void set_slot_connected_handler(std::function<void(void)> f)
+    void set_slot_connected_handler(std::function<void(const json&)> f)
     {
         _hOnSlotConnected = f;
     }
@@ -621,7 +621,6 @@ private:
                 }
                 else if (cmd == "Connected") {
                     _state = State::SLOT_CONNECTED;
-                    if (_hOnSlotConnected) _hOnSlotConnected();
                     _team = command["team"];
                     _slotnr = command["slot"];
                     _players.clear();
@@ -642,6 +641,7 @@ private:
                         if (!checkedLocations.empty())
                             _hOnLocationChecked(checkedLocations);
                     }
+                    if (_hOnSlotConnected) _hOnSlotConnected(command["slot_data"]);
                 }
                 else if (cmd == "ReceivedItems") {
                     std::list<NetworkItem> items;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -785,7 +785,7 @@ private:
 
     std::function<void(void)> _hOnSocketConnected = nullptr;
     std::function<void(void)> _hOnSocketDisconnected = nullptr;
-    std::function<void(void)> _hOnSlotConnected = nullptr;
+    std::function<void(const json&)> _hOnSlotConnected = nullptr;
     std::function<void(void)> _hOnSlotDisconnected = nullptr;
     std::function<void(const std::list<std::string>&)> _hOnSlotRefused = nullptr;
     std::function<void(void)> _hOnRoomInfo = nullptr;


### PR DESCRIPTION
This change makes the `slot_data` dict provided by the Connected packet available to the handler referenced by `_hOnSlotConnected`. Some games may need this data for purposes such as identifying the goal, determining whether DeathLink is enabled, or more.