### PR TITLE
Send queued checks and scouts locations on "Connected" command

### DIFF
--- a/apclient.hpp
+++ b/apclient.hpp
@@ -789,6 +789,7 @@ private:
                         for (int64_t location : _checkQueue) {
                             queuedChecks.push_back(location);
                         }
+                        _checkQueue.clear();
                         LocationChecks(queuedChecks);
                     }
                     if (!_scoutQueue.empty()) {
@@ -796,6 +797,7 @@ private:
                         for (int64_t location : _scoutQueue) {
                             queuedScouts.push_back(location);
                         }
+                        _scoutQueue.clear();
                         LocationScouts(queuedScouts);
                     }
         

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -411,7 +411,6 @@ public:
             _ws->send(packet.dump());
         } else {
             _checkQueue.insert(locations.begin(), locations.end());
-            // FIXME: this needs to be sent at some point
         }
         return true;
     }
@@ -428,7 +427,6 @@ public:
             _ws->send(packet.dump());
         } else {
             _scoutQueue.insert(locations.begin(), locations.end());
-            // FIXME: this needs to be sent at some point
         }
         return true;
     }
@@ -772,6 +770,23 @@ private:
                         if (!checkedLocations.empty())
                             _hOnLocationChecked(checkedLocations);
                     }
+
+                    //Send the checks and scouts queued if any
+                    if (!_checkQueue.empty()) {
+                        std::list<int64_t> queuedChecks;
+                        for (int64_t location : _checkQueue) {
+                            queuedChecks.push_back(location);
+                        }
+                        LocationChecks(queuedChecks);
+                    }
+                    if (!_scoutQueue.empty()) {
+                        std::list<int64_t> queuedScouts;
+                        for (int64_t location : _scoutQueue) {
+                            queuedScouts.push_back(location);
+                        }
+                        LocationScouts(queuedScouts);
+                    }
+        
                 }
                 else if (cmd == "ReceivedItems") {
                     std::list<NetworkItem> items;


### PR DESCRIPTION
I suggest an implementation to send the queues locations to the server while the library receives the "Connected" command.


You can check the logs attached where I performed the following steps : 
- I played the game while Connected
- I disabled my network card 
- I checked a location 
- I enabled my network card

The following logs mean that I picked up an item and I sent the corresponding location to the apclientpp library.
`itemId : 21240000`
`List not empty`
`Clear the list`

[reconnection_logs.txt](https://github.com/black-sliver/apclientpp/files/9328689/reconnection_logs.txt)
