### PR TITLE
unique_ptr and rework UUID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ C++ Archipelago multiworld randomizer client library. See [archipelago.gg](https
 * add dependencies to your project
   * [nlohmann/json](https://github.com/nlohmann/json)
   * [tristanpenman/valijson](https://github.com/tristanpenman/valijson)
+    (unless disabled, see [Build Configuration](#build-configuration))
   * [black-sliver/wswrap](https://github.com/black-sliver/wswrap)
   * for desktop: [zaphoyd/websocketpp](https://github.com/zaphoyd/websocketpp)
   * for desktop: asio (and define ASIO_STANDALONE) or boost::asio
@@ -42,16 +43,29 @@ C++ Archipelago multiworld randomizer client library. See [archipelago.gg](https
   * remove calls to `save_data_package` and don't save data package in `set_data_package_changed_handler`
   * you can still use `set_data_package` or `set_data_package_from_file` during migration to make use of the old cache
     (they are marked as deprecated and will go away in the next version)
-* see [ap-soeclient](https://github.com/black-sliver/ap-soeclient) for an example
+* see [Implementations](#implementations) for examples
 * see [Gotchas](#gotchas)
 
 
-## Additional Configuration
+## Build Configuration
 
-* use `-DWSWRAP_SEND_EXCEPTIONS` or `#define WSWRAP_SEND_EXCEPTIONS` before including anything to get exceptions when
-  a send fails
-* use `-DAP_NO_DEFAULT_DATA_PACKAGE_STORE` or `#define AP_NO_DEFAULT_DATA_PACKAGE_STORE` before including to not use
-  DefaultDataPackageStore automatically.
+Some features/behaviors can be disabled/switched using compile time definitions.
+
+Use
+`-D<definition>` (gcc, clang),
+`add_compile_definitions(<definition>)` (cmake),
+`project properties -> C/C++ -> Preprocessor -> Preprocessor Definitions` (VS),
+`/D<definition>` (vc command line) or
+`#define <definition>` (in code, before include).
+
+* `ASIO_STANDALONE` to use asio/`asio.hpp` directly, not via boost.
+* `APCLIENT_DEBUG` write debug output to stdout.
+* `AP_NO_DEFAULT_DATA_PACKAGE_STORE` to not use DefaultDataPackageStore automatically.
+* `AP_NO_SCHEMA` disables schema validation.
+  It's not required, shrinks the built binary and removes dependency on valijson.
+* `AP_PREFER_UNENCRYPTED` try unencrypted connection first. Only useful for testing.
+* `WSWRAP_SEND_EXCEPTIONS` to get exceptions when a send fails.
+* `WSWRAP_NO_SSL` to disable SSL support. Only recommended for testing.
 
 
 ## When using Visual Studio for building
@@ -63,7 +77,8 @@ C++ Archipelago multiworld randomizer client library. See [archipelago.gg](https
     * Add subprojects\websocketpp
     * Add subprojects\wswrap\include
     * Add subprojects\json\include
-    * Add subprojects\valijson\include 
+    * Add subprojects\valijson\include
+      (unless disabled, see [Build Configuration](#build-configuration))
 * Add `/Zc:__cplusplus` to the command line
   * project properties -> C/C++ -> Command Line -> Additional Options
 * Add `_WIN32_WINNT=0x0600` (or higher) to Preprocessor Definitions

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -675,7 +675,7 @@ public:
         return BLANK;
     }
 
-    std::string get_location_name(int64_t code, const std::string& game="")
+    std::string get_location_name(int64_t code, const std::string& game)
     {
         if (game.empty()) { // old code path ("global" ids)
             auto it = _locations.find(code);
@@ -693,6 +693,12 @@ public:
         return "Unknown";
     }
 
+    [[deprecated("Use the overload that explicitly takes game argument")]]
+    std::string get_location_name(int64_t code)
+    {
+        return get_location_name(code, "");
+    }
+
     /*Usage is not recommended
     * Return the id associated with the location name
     * Return APClient::INVALID_NAME_ID when undefined*/
@@ -707,7 +713,7 @@ public:
         return INVALID_NAME_ID;
     }
 
-    std::string get_item_name(int64_t code, const std::string& game="")
+    std::string get_item_name(int64_t code, const std::string& game)
     {
         if (game.empty()) { // old code path ("global" ids)
             auto it = _items.find(code);
@@ -723,6 +729,12 @@ public:
             }
         }
         return "Unknown";
+    }
+
+    [[deprecated("Use the overload that explicitly takes game argument")]]
+    std::string get_item_name(int64_t code)
+    {
+        return get_item_name(code, "");
     }
 
     /*Usage is not recommended

--- a/apuuid.hpp
+++ b/apuuid.hpp
@@ -10,10 +10,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #ifndef _APUUID_HPP
 #define _APUUID_HPP
 
+/*
+ * NOTE: this does not produce "real" UUIDs. AP just requires strings that are unlikely to collide.
+ * This provides implementation for both browser context via emscripten as well as libc.
+ * We use a singleton to properly initialize RNG once.
+ * If calling srand() is a problem for the callee, you'll have to provide your own UUID generator.
+ */
 
 #include <stdint.h>
 #include <stdio.h>
 #include <string>
+#include <memory>
+#include <fstream>
 
 
 #ifdef __EMSCRIPTEN__
@@ -25,67 +33,203 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 
-static void apuuid_init_rng()
-{
-    #ifdef __EMSCRIPTEN__
-    /* js crypto needs no init from C */
-    #else
-    srand ((unsigned int) time (NULL));
-    #endif
-}
-
-static uint8_t apuuid_rand_byte()
-{
-    #ifdef __EMSCRIPTEN__
-    return (uint8_t)EM_ASM_INT({
-        var buf = new Uint8Array(1);
-        crypto.getRandomValues(buf);
-        return buf[0];
-    });
-    #else
-    return rand();
-    #endif
-}
-
-static void apuuid_generate(char* out)
-{
-    for (uint8_t i=0; i<16; i++) {
-        sprintf(out + 2*i, "%02hhx", apuuid_rand_byte());
-    }
-}
-
-static std::string ap_get_uuid(const std::string& uuidFile)
-{
-    char uuid[33]; uuid[32] = 0;
-#if defined USE_IDBFS || !defined __EMSCRIPTEN__
-    FILE* f = uuidFile.empty() ? nullptr : fopen(uuidFile.c_str(), "rb");
-    size_t n = 0;
-    if (f) {
-        n = fread(uuid, 1, 32, f);
-        fclose(f);
-    }
-    if (!f || n < 32) {
-        apuuid_init_rng();
-        apuuid_generate(uuid);
-        f = uuidFile.empty() ? nullptr : fopen(uuidFile.c_str(), "wb");
-        if (f) {
-            n = fwrite(uuid, 1, 32, f);
-            fclose(f);
-            #ifdef __EMSCRIPTEN__
-            EM_ASM(
-                FS.syncfs(function (err) {}); // cppcheck-suppress unknownMacro
-            );
-            #endif
+namespace AP {
+    class UUID {
+    public:
+        UUID(uint8_t bytes[16])
+        {
+            const char hex[] = "0123456789abcdef";
+            _string.resize(32);
+            char* p = (char*)_string.data();
+            for (size_t i=0; i<16; i++) {
+                *p = hex[(bytes[i] >> 4) & 0x0f];
+                p++;
+                *p = hex[bytes[i] & 0x0f];
+                p++;
+            }
         }
-        if (!uuidFile.empty() && (!f || n < 32)) {
-            fprintf(stderr, "Could not write persistent UUID!\n");
+
+        virtual ~UUID() {}
+
+        const std::string& string() const
+        {
+            return _string;
         }
+
+    private:
+        std::string _string;
+    };
+
+    class UUIDFactory {
+    public:
+        static UUIDFactory* instance();
+        virtual ~UUIDFactory() {}
+        void setFilename(const std::string& filename);
+        UUID getPersistentUUID(const std::string& hostname_or_url);
+
+    private:
+        UUIDFactory();
+        uint8_t randByte() const;
+        UUID generate() const;
+        void generate(uint8_t bytes[8]) const;
+        uint8_t hash(const std::string& name) const;
+
+        std::string _filename;
+        std::fstream _f;
+    };
+
+    inline UUIDFactory* UUIDFactory::instance()
+    {
+        static auto singleton = std::unique_ptr<UUIDFactory>(new UUIDFactory());
+        return singleton.get();
     }
-    f = nullptr;
-#else
-    #error TODO: implement localStorage API
+
+    void UUIDFactory::setFilename(const std::string& filename)
+    {
+#if defined __EMSCRIPTEN__ && !defined USE_IDBFS
+#error "IDBFS is currently required for emscripten"
 #endif
-    return uuid;
+        if (_filename == filename)
+            return;
+        if (_f.is_open())
+            _f.close();
+        _filename = filename;
+    }
+
+    UUID UUIDFactory::getPersistentUUID(const std::string& name)
+    {
+        if (!_f.is_open()) {
+            if (_filename.empty())
+                return generate();
+
+            _f.open(_filename, std::fstream::in | std::fstream::out | std::fstream::binary | std::fstream::ate);
+            if (!_f.is_open())
+                _f.open(_filename, std::fstream::in | std::fstream::out | std::fstream::binary | std::fstream::trunc);
+            if (!_f.is_open()) {
+                fprintf(stderr, "Could not write persistent UUID!\n");
+                return generate();
+            }
+            if (_f.tellp() < 32) {
+                // insert back compat string
+                _f.seekp(0);
+                _f << generate().string();
+                _f.flush();
+            }
+            if (_f.tellp() < 64) {
+                // insert old UUID into slot 0
+                uint64_t state = 1;
+                uint64_t dummy = 0;
+                uint8_t bytes[16];
+                _f.seekg(0);
+                for (uint8_t i=0; i<16; i++) {
+                    char c;
+                    uint8_t b = 0;
+                    for (uint8_t n=0; n<2; n++) {
+                        b <<= 4;
+                        _f.read(&c, 1);
+                        if (c >= '0' && c <= '9')
+                            b |= (uint8_t)(c - '0');
+                        if (c >= 'a' && c <= 'f')
+                            b |= (uint8_t)(c - 'a' + 0x0a);
+                        if (c >= 'A' && c <= 'F')
+                            b |= (uint8_t)(c - 'A' + 0x0a);
+                    }
+                    bytes[i] = b;
+                }
+                _f.seekp(32);
+                _f.write((const char*)&state, sizeof(state));
+                _f.write((const char*)&dummy, sizeof(dummy));
+                _f.write((const char*)bytes, sizeof(bytes));
+                _f.flush();
+            }
+        }
+        // 32 byte at start of file reserved for back compat
+        // then each entry is 8 byte state + 8 byte reserved + 16 byte uuid
+        size_t offset = 32 + (size_t) hash(name) * 32;
+        _f.seekg(offset);
+        uint64_t state;
+        uint64_t dummy;
+        uint8_t bytes[16];
+
+        // load existing UUID if it exists
+        if (_f.read((char*)&state, sizeof(state)) && state
+                && _f.read((char*)&dummy, sizeof(dummy))
+                && _f.read((char*)bytes, sizeof(bytes)))
+            return UUID(bytes);
+
+        // expand file
+        _f.clear();
+        _f.seekp(0, std::fstream::end);
+        dummy = 0;
+        while (_f.tellp() < offset)
+            if (!_f.write((const char*)&dummy, sizeof(dummy)))
+                return generate(); // should never happen
+
+        // write new UUID
+        _f.seekp(offset);
+        state = 1;
+        generate(bytes);
+        _f.write((const char*)&state, sizeof(state));
+        _f.write((const char*)&dummy, sizeof(dummy));
+        _f.write((const char*)&bytes, sizeof(bytes));
+        _f.flush();
+        return UUID(bytes);
+    }
+
+    void UUIDFactory::generate(uint8_t bytes[8]) const
+    {
+        for (size_t i=0; i<8; i++)
+            bytes[i] = randByte();
+    }
+
+    UUID UUIDFactory::generate() const
+    {
+        uint8_t bytes[8];
+        generate(bytes);
+        return UUID(bytes);
+    }
+
+    uint8_t UUIDFactory::hash(const std::string& name) const
+    {
+        uint8_t res = 0;
+        for (char c: name) {
+            res = (res >> 7) | (res << 1);
+            res = (uint8_t)(res + (uint8_t)c);
+        }
+        return res;
+    }
+
+#ifdef __EMSCRIPTEN__
+    UUIDFactory::UUIDFactory()
+    {
+        /* js crypto needs no init from C */
+    }
+
+    uint8_t UUIDFactory::randByte() const
+    {
+        return (uint8_t)EM_ASM_INT({
+            var buf = new Uint8Array(1);
+            crypto.getRandomValues(buf);
+            return buf[0];
+        });
+    }
+#else
+    UUIDFactory::UUIDFactory()
+    {
+        srand ((unsigned int) time (NULL));
+    }
+
+    uint8_t UUIDFactory::randByte() const
+    {
+        return rand();
+    }
+#endif
+}
+
+static std::string ap_get_uuid(const std::string& uuidFile, const std::string& host="")
+{
+    AP::UUIDFactory::instance()->setFilename(uuidFile);
+    return AP::UUIDFactory::instance()->getPersistentUUID(host).string();
 }
 
 #endif // _APUUID_HPP


### PR DESCRIPTION
* use unique_ptr for auto-created data storage and websocket
* fix `AP_NO_DEFAULT_DATA_PACKAGE_STORE` code path not working
* rework UUID generation
  * use fstream instead of FILE*, hopefully getting rid of MSVC warnings
  * when a UUID (cache) filename is supplied, this now generates 256 different UUIDs based on a new optional "hostname" parameter. This can be used to send different string to different rooms/hosts.
  * the updated cache file should be forwards and backwards compatible
* Deprecate get_location_name without game