### PR TITLE
Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ C++ Archipelago multiworld randomizer client library. See [archipelago.gg](https
   * use `Bounce` to send a bounce (deathlink, ...)
   * use `Get`, `Set` and `SetNotify` to access data storage api,
     see [Archipelago network protocol](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#get)
-  * by default we now use the shared data package cache in %LocalAppData%/Archipelago/Cache or ~/.cache/Archipelago.
+  * by default, we now use the shared data package cache in %LocalAppData%/Archipelago/Cache or ~/.cache/Archipelago.
     This can be changed by passing a custom APDataPackageStore into APClient.
 * when upgrading from 0.3.8 or older
   * remove calls to `save_data_package` and don't save data package in `set_data_package_changed_handler`
@@ -66,19 +66,29 @@ Use
 * `AP_PREFER_UNENCRYPTED` try unencrypted connection first. Only useful for testing.
 * `WSWRAP_SEND_EXCEPTIONS` to get exceptions when a send fails.
 * `WSWRAP_NO_SSL` to disable SSL support. Only recommended for testing.
+* `WSWRAP_NO_COMPRESSION` to disable compression. Only recommended for testing.
 
 
 ## When using Visual Studio for building
 
 * follow steps mentioned above
 * Set up Additional Include Directories for the dependencies
-  * project properties -> C/C++ -> General -> Additional Include Directories
+  * Project Properties -> C/C++ -> General -> Additional Include Directories
     * Add subprojects\asio\include
     * Add subprojects\websocketpp
     * Add subprojects\wswrap\include
     * Add subprojects\json\include
     * Add subprojects\valijson\include
       (unless disabled, see [Build Configuration](#build-configuration))
+    * Add openssl and zlib include directories if required (SSL and compression support)
+* Set up Additional Link Libraries for openssl and zlib
+  * Optional: Configuration Properties -> Linker -> General -> Additional Library Directories
+    * Add folder where `libcrypto_*.lib` and `libssl_*.lib` are (for SSL support)
+    * Add folder where `libz.lib` is (for compression support)
+  * Configuration Properties -> Linker -> Input -> Additional Dependencies
+    * Add `libcrypto_*.lib` and `libssl_*.lib` (for SSL support)
+    * Add `libz.lib` (for compression support)
+  * Alternatively use `#pragma comment(lib, "lib_name")` in any cpp file if Library Directories are set correctly
 * Add `/Zc:__cplusplus` to the command line
   * project properties -> C/C++ -> Command Line -> Additional Options
 * Add `_WIN32_WINNT=0x0600` (or higher) to Preprocessor Definitions
@@ -125,6 +135,13 @@ To add SSL/wss support on desktop, the following steps are required:
   * load the cert store by passing the path as 4th argument to APClient's constructor
 * apclient will try to load system certs, but this should only be used for testing:
   outdated Windows has outdated certs, macos/Linux without OpenSSL or with a different version won't find any certs
+
+
+## Compression Support
+
+To enable "permessage-deflate" compression support on desktop, update wswrap to 1.03.00 or newer and link with libz.
+
+Context takeover is not supported.
 
 
 ## Callbacks

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -613,6 +613,12 @@ public:
         return BLANK;
     }
 
+    /// Get the currently played game name or an empty string
+    const std::string& get_game()
+    {
+        return get_player_game(get_player_number());
+    }
+
     std::string get_location_name(int64_t code, const std::string& game)
     {
         if (game.empty()) { // old code path ("global" ids)

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -569,68 +569,6 @@ public:
         });
     }
 
-    [[deprecated("Data package is handled through APDataPackageStore now")]]
-    void set_data_package(const json& data)
-    {
-        // only apply from cache if not updated and it looks valid
-        if (!_dataPackageValid && data.find("games") != data.end())
-            _set_data_package(data);
-    }
-
-    [[deprecated("Data package is handled through APDataPackageStore now")]]
-    bool set_data_package_from_file(const std::string& path)
-    {
-        FILE* f;
-
-        if (!_dataPackageValid)
-            return true;
-
-#ifdef _MSC_VER
-        if ((fopen_s(&f, path.c_str(), "rb")) != 0)
-#else
-        if ((f = fopen(path.c_str(), "rb")) == NULL)
-#endif
-            return false;
-        char* buf = nullptr;
-        size_t len = (size_t)0;
-        if ((0 == fseek(f, 0, SEEK_END)) &&
-            ((len = ftell(f)) > 0) &&
-            ((buf = (char*)malloc(len+1))) &&
-            (0 == fseek(f, 0, SEEK_SET)) &&
-            (len == fread(buf, 1, len, f)))
-        {
-            buf[len] = 0;
-            try {
-                auto data = json::parse(buf);
-                if (data.find("games") != data.end())
-                    _set_data_package(data);
-            } catch (const std::exception&) {
-                free(buf);
-                fclose(f);
-                throw;
-            }
-        }
-        free(buf);
-        fclose(f);
-        return true;
-    }
-
-    [[deprecated("Data package is handled through APDataPackageStore now")]]
-    bool save_data_package(const std::string& path)
-    {
-        FILE* f;
-#ifdef _MSC_VER
-        if ((fopen_s(&f, path.c_str(), "wb")) != 0)
-#else
-        if ((f = fopen(path.c_str(), "wb")) == NULL)
-#endif
-            return false;
-        std::string s = _dataPackage.dump();
-        fwrite(s.c_str(), 1, s.length(), f);
-        fclose(f);
-        return true;
-    }
-
     const std::set<int64_t> get_checked_locations() const
     {
         return _checkedLocations;
@@ -693,12 +631,6 @@ public:
         return "Unknown";
     }
 
-    [[deprecated("Use the overload that explicitly takes game argument")]]
-    std::string get_location_name(int64_t code)
-    {
-        return get_location_name(code, "");
-    }
-
     /*Usage is not recommended
     * Return the id associated with the location name
     * Return APClient::INVALID_NAME_ID when undefined*/
@@ -729,12 +661,6 @@ public:
             }
         }
         return "Unknown";
-    }
-
-    [[deprecated("Use the overload that explicitly takes game argument")]]
-    std::string get_item_name(int64_t code)
-    {
-        return get_item_name(code, "");
     }
 
     /*Usage is not recommended

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -791,7 +791,7 @@ public:
     }
 
     bool ConnectSlot(const std::string& name, const std::string& password, int items_handling,
-                     const std::list<std::string>& tags = {}, const Version& ver = {0, 2, 6})
+                     const std::list<std::string>& tags = {}, const Version& ver = {0, 4, 9})
     {
         if (_state < State::SOCKET_CONNECTED)
             return false;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -385,6 +385,11 @@ public:
         _hOnRoomInfo = f;
     }
 
+    void set_room_update_handler(std::function<void(void)> f)
+    {
+        _hOnRoomUpdate = f;
+    }
+
     void set_items_received_handler(std::function<void(const std::list<NetworkItem>&)> f)
     {
         _hOnItemsReceived = f;
@@ -1384,6 +1389,8 @@ private:
                             });
                         }
                     }
+                    if (_hOnRoomUpdate)
+                        _hOnRoomUpdate();
                 }
                 else if (cmd == "DataPackage") {
                     auto data = _dataPackage;
@@ -1561,6 +1568,7 @@ private:
     std::function<void(void)> _hOnSlotDisconnected = nullptr;
     std::function<void(const std::list<std::string>&)> _hOnSlotRefused = nullptr;
     std::function<void(void)> _hOnRoomInfo = nullptr;
+    std::function<void(void)> _hOnRoomUpdate = nullptr;
     std::function<void(const std::list<NetworkItem>&)> _hOnItemsReceived = nullptr;
     std::function<void(const std::list<NetworkItem>&)> _hOnLocationInfo = nullptr;
     std::function<void(const json&)> _hOnDataPackageChanged = nullptr;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -1364,9 +1364,10 @@ private:
                     std::list<int64_t> checkedLocations;
                     for (const auto& j: command["checked_locations"]) {
                         int64_t location = j.get<int64_t>();
-                        checkedLocations.push_back(location);
-                        _checkedLocations.insert(location);
-                        _missingLocations.erase(location);
+                        if (_checkedLocations.emplace(location).second) {
+                            checkedLocations.push_back(location);
+                            _missingLocations.erase(location);
+                        }
                     }
                     if (_hOnLocationChecked && !checkedLocations.empty())
                         _hOnLocationChecked(checkedLocations);


### PR DESCRIPTION
This is a breaking API change

* Remove deprecated methods

* Add helper function get_game() for get_location_name()/_item_name()

* Do not forward duplicates to on_location_checked handler
    
    Archipelago server may send the same location multiple times.
    This change filters them out before running the handler.
