### PR TITLE
Implement new features, AP 0.6.0 feature parity, bump version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ C++ Archipelago multiworld randomizer client library. See [archipelago.gg](https
     This can be changed by passing a custom APDataPackageStore into APClient.
 * when upgrading from 0.3.8 or older
   * remove calls to `save_data_package` and don't save data package in `set_data_package_changed_handler`
-  * you can still use `set_data_package` or `set_data_package_from_file` during migration to make use of the old cache
-    (they are marked as deprecated and will go away in the next version)
 * see [Implementations](#implementations) for examples
 * see [Gotchas](#gotchas)
 

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -59,6 +59,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define WSWRAP_VERSION 10000 // 1.0 did not have this define
 #endif
 
+#ifndef __EMSCRIPTEN__
+#if WSWRAP_VERSION < 10300
+#warning "Please update wswrap to enable compression! Archipelago will require compression in the future."
+#elif defined WSWRAP_NO_COMPRESSION
+#warning "Don't disable it in prod! Archipelago will require compression in the future."
+#endif
+#endif
+
 
 /**
  * Abstract data package storage handler.

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -653,9 +653,11 @@ public:
         return "Unknown";
     }
 
-    /*Usage is not recommended
-    * Return the id associated with the location name
-    * Return APClient::INVALID_NAME_ID when undefined*/
+    /**
+     * Usage is not recommended
+     * Return the id associated with the location name
+     * Return APClient::INVALID_NAME_ID when undefined
+     */
     int64_t get_location_id(const std::string& name) const
     {
         if (_dataPackage["games"].contains(_game)) {
@@ -685,9 +687,11 @@ public:
         return "Unknown";
     }
 
-    /*Usage is not recommended
-    * Return the id associated with the item name
-    * Return APClient::INVALID_NAME_ID when undefined*/
+    /**
+     * Usage is not recommended
+     * Return the id associated with the item name
+     * Return APClient::INVALID_NAME_ID when undefined
+     */
     int64_t get_item_id(const std::string& name) const
     {
         if (_dataPackage["games"].contains(_game)) {

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -326,6 +326,9 @@ public:
 
         static Version from_json(const nlohmann::json& j)
         {
+            if (j.is_null()) {
+                return {0, 0, 0};
+            }
             return {
                 j.value("major", 0),
                 j.value("minor", 0),
@@ -1079,6 +1082,18 @@ public:
         return _serverConnectTime + td.count();
     }
 
+    /// Get the version of the server currently connected to
+    Version get_server_version() const
+    {
+        return _serverVersion;
+    }
+
+    /// Get the version of AP that generated the game connected to
+    Version get_generator_version() const
+    {
+        return _generatorVersion;
+    }
+
     /**
      * Poll the network layer and dispatch callbacks.
      * This has to be called repeatedly (i.e. once per frame) while this object exists.
@@ -1151,6 +1166,7 @@ private:
         log("Server connected");
         _state = State::SOCKET_CONNECTED;
         _pendingDataPackageRequests = 0;
+        _serverVersion = _generatorVersion = Version{0, 0, 0};
         if (_hOnSocketConnected) _hOnSocketConnected();
         _socketReconnectInterval = 1500;
     }
@@ -1199,6 +1215,7 @@ private:
                     _localConnectTime = std::chrono::steady_clock::now();
                     _serverConnectTime = command["time"].get<double>();
                     _serverVersion = Version::from_json(command["version"]);
+                    _generatorVersion = Version::from_json(command["generator_version"]);
                     _seed = command["seed_name"];
                     _hintCostPercent = command.value("hint_cost", 0);
                     _hasPassword = command.value("password", false);
@@ -1636,6 +1653,7 @@ private:
     double _serverConnectTime = 0;
     std::chrono::steady_clock::time_point _localConnectTime;
     Version _serverVersion = {0,0,0};
+    Version _generatorVersion = {0,0,0};
     int _locationCount = 0;
     int _hintCostPercent = 0;
     int _hintPoints = 0;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -11,6 +11,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define _APCLIENT_HPP
 
 
+#define APCLIENTPP_VERSION_INITIALIZER {0, 6, 0}
+
+
 #if defined _WSWRAP_HPP && !defined WSWRAP_SEND_EXCEPTIONS
 #warning "Can't set exception behavior. wswrap already included"
 #elif !defined WSWRAP_SEND_EXCEPTIONS
@@ -852,7 +855,7 @@ public:
     }
 
     bool ConnectSlot(const std::string& name, const std::string& password, int items_handling,
-                     const std::list<std::string>& tags = {}, const Version& ver = {0, 4, 9})
+                     const std::list<std::string>& tags = {}, const Version& ver = APCLIENTPP_VERSION_INITIALIZER)
     {
         if (_state < State::SOCKET_CONNECTED)
             return false;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -233,6 +233,14 @@ public:
         FLAG_TRAP = 4,
     };
 
+    enum HintStatus {
+        HINT_UNSPECIFIED = 0,  ///< The receiving player has not specified any status
+        HINT_NO_PRIORITY = 10, ///< The receiving player has specified that the item is unneeded
+        HINT_AVOID = 20,       ///< The receiving player has specified that the item is detrimental
+        HINT_PRIORITY = 30,    ///< The receiving player has specified that the item is needed
+        HINT_FOUND = 40,       ///< The location has been collected. Status cannot be changed once found.
+    };
+
     enum class SlotType : int {
         SPECTATOR = 0,
         PLAYER = 1,
@@ -277,6 +285,7 @@ public:
         std::string text;
         int player = 0;
         unsigned flags = FLAG_NONE;
+        unsigned hintStatus = HINT_UNSPECIFIED;
 
         static TextNode from_json(const json& j)
         {
@@ -286,6 +295,7 @@ public:
             node.text = j.value("text", "");
             node.player = j.value("player", 0);
             node.flags = j.value("flags", 0U);
+            node.hintStatus = j.value("hint_status", 0U);
             return node;
         }
     };

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -742,6 +742,14 @@ public:
                 int64_t id = stoi64(node.text);
                 if (color.empty()) color = "blue";
                 text = get_location_name(id, get_player_game(node.player));
+            } else if (node.type == "hint_status") {
+                text = node.text;
+                if (node.hintStatus == HINT_FOUND) color = "green";
+                else if (node.hintStatus == HINT_UNSPECIFIED) color = "grey";
+                else if (node.hintStatus == HINT_NO_PRIORITY) color = "slateblue";
+                else if (node.hintStatus == HINT_AVOID) color = "salmon";
+                else if (node.hintStatus == HINT_PRIORITY) color = "plum";
+                else color = "red";  // unknown status -> red
             } else {
                 text = node.text;
             }
@@ -1597,6 +1605,8 @@ private:
         if (color == "plum") return "\x1b[38:5:219m";
         if (color == "slateblue") return "\x1b[38:5:62m";
         if (color == "salmon") return "\x1b[38:5:210m";
+        if (color == "gray") return "\x1b[90m";
+        if (color == "grey") return "\x1b[90m";
         return "\x1b[0m";
     }
 


### PR DESCRIPTION
* Adds support for hint priority / HintStatus and UpdateHint
* This adds a new color "grey" with ansi code 90
* Also changes the way DataPackage is fetched to be more streaming / less blocking
  * fetch games in groups of two: receive the next part while parsing the previous while still allowing for better compressibility than single game fetches
* Warn if the build will not be able to support compression
* Drop support for old GetDataPackage from AP < 0.3.2
* Add accessors for server version and generator version
* Update some comments to be doc comments (doxygen / javadoc style) instead of regular comments
* Add define for `APCLIENTPP_VERSION_INITIALIZER`
  * You can use this as `APClient::Version libVersion = APCLIENTPP_VERSION_INITIALIZER;`