### PR TITLE
add slot_concerns_self function

### DIFF
--- a/apclient.hpp
+++ b/apclient.hpp
@@ -723,7 +723,7 @@ public:
             return true;
         auto it = _slotInfo.find(slot);
         if (it != _slotInfo.end()) {
-            std::list<int> members = it->second.members;
+            const auto& members = it->second.members;
             return std::find(members.begin(), members.end(), _slotnr) != members.end();
         }
         return false;

--- a/apclient.hpp
+++ b/apclient.hpp
@@ -717,6 +717,18 @@ public:
         return INVALID_NAME_ID;
     }
 
+    bool slot_concerns_self(int slot) const
+    {
+        if (slot == _slotnr)
+            return true;
+        auto it = _slotInfo.find(slot);
+        if (it != _slotInfo.end()) {
+            std::list<int> members = it->second.members;
+            return std::find(members.begin(), members.end(), _slotnr) != members.end();
+        }
+        return false;
+    }
+
     std::string render_json(const std::list<TextNode>& msg, RenderFormat fmt = RenderFormat::TEXT)
     {
         // TODO: implement RenderFormat::HTML
@@ -730,7 +742,7 @@ public:
             if (fmt != RenderFormat::TEXT) color = node.color;
             if (node.type == "player_id") {
                 int id = std::stoi(node.text);
-                if (color.empty() && id == _slotnr) color = "magenta";
+                if (color.empty() && slot_concerns_self(id)) color = "magenta";
                 else if (color.empty()) color = "yellow";
                 text = get_player_alias(id);
             } else if (node.type == "item_id") {


### PR DESCRIPTION
This PR adds a `bool slot_concerns_self(int slot)` function which returns true if the `slot` parameter is equal to the current player's slot number or if it matches a group that the player is a member of. Users should call `slot_concerns_self(slot)` instead of using `slot == get_player_number()` when checking if a slot id is applicable to the current player.

One use case I know of for groups is item links, which puts the items in a group slot. ItemSend packets will report that the group is the receiver when an item in the item link is found.

`slot_info` in the Connected packet is stored in `_slotInfo`, but it is private and was previously only used in `get_player_game`, so it wasn't possible before to do this kind of check.