### PR TITLE
Add option to receive own LocationChecks from server

### DIFF
--- a/apclient.hpp
+++ b/apclient.hpp
@@ -599,6 +599,15 @@ public:
         });
     }
 
+    /// Set location sending/receiving mode:
+    /// If receiveOwnLocations is set to true, missing and checked locations
+    /// won't update until the server acknowledges the LocationChecks and
+    /// on_location_checks will be run even for sent LocationChecks.
+    void set_receive_own_locations(bool receiveOwnLocations)
+    {
+        _receiveOwnLocations = receiveOwnLocations;
+    }
+
     const std::set<int64_t> get_checked_locations() const
     {
         return _checkedLocations;
@@ -801,9 +810,12 @@ public:
         } else {
             _checkQueue.insert(locations.begin(), locations.end());
         }
-        for (const auto& location: locations) {
-            _checkedLocations.insert(location);
-            _missingLocations.erase(location);
+        if (!_receiveOwnLocations) {
+            // for receiveOwnLocations, this will be done on the server response instead
+            for (const auto& location: locations) {
+                _checkedLocations.insert(location);
+                _missingLocations.erase(location);
+            }
         }
         return true;
     }
@@ -1773,6 +1785,7 @@ private:
     int _locationCount = 0;
     int _hintCostPercent = 0;
     int _hintPoints = 0;
+    bool _receiveOwnLocations = false;
     std::set<int64_t> _checkedLocations;
     std::set<int64_t> _missingLocations;
     APDataPackageStore* _dataPackageStore;


### PR DESCRIPTION
@NewSoupVi this should work for Witness. Can you test?

After instantiating the APClient, run `ap.set_receive_own_locations(true);`