### PR TITLE
Add CONNECTED to ClientStatus enum

### DIFF
--- a/apclient.hpp
+++ b/apclient.hpp
@@ -232,6 +232,7 @@ public:
 
     enum class ClientStatus : int {
         UNKNOWN = 0,
+        CONNECTED = 5,
         READY = 10,
         PLAYING = 20,
         GOAL = 30,


### PR DESCRIPTION
Added missing CONNECTED enum value from [Archipelago api](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#ClientStatus)